### PR TITLE
Add package for wdio-phantomjs-service

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sinon": "^1.17.5",
     "wdio-firefox-profile-service": "0.0.1",
     "wdio-mocha-framework": "^0.5.8",
+    "wdio-phantomjs-service": "^0.2.2",
     "wdio-selenium-standalone-service": "0.0.8",
     "wdio-spec-reporter": "0.0.5",
     "webdriverio": "^4.2.3"


### PR DESCRIPTION
I was getting "ERROR: Unable to create new service: PhantomJSDriverService". It would run with chrome and firefox just fine as is. This package adds support for phantomjs service.